### PR TITLE
Fix PostgREST injection, CORS wildcard, and missing ErrorBoundary

### DIFF
--- a/netlify/functions/_shared/cors.ts
+++ b/netlify/functions/_shared/cors.ts
@@ -1,9 +1,14 @@
-export const CORS_HEADERS: Record<string, string> = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-};
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS || 'https://christensenplumbing.com').split(',');
 
-export function handleOptions(): Response {
-  return new Response(null, { status: 204, headers: CORS_HEADERS });
+export function getCorsHeaders(origin?: string | null): Record<string, string> {
+  const allowedOrigin = ALLOWED_ORIGINS.includes(origin || '') ? origin! : ALLOWED_ORIGINS[0];
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  };
+}
+
+export function handleOptions(request: Request): Response {
+  return new Response(null, { status: 204, headers: getCorsHeaders(request.headers.get('Origin')) });
 }

--- a/netlify/functions/_shared/response.ts
+++ b/netlify/functions/_shared/response.ts
@@ -1,12 +1,12 @@
-import { CORS_HEADERS } from './cors';
+import { getCorsHeaders } from './cors';
 
-export function jsonResponse(data: unknown, status = 200): Response {
+export function jsonResponse(data: unknown, status = 200, origin?: string | null): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    headers: { ...getCorsHeaders(origin), 'Content-Type': 'application/json' },
   });
 }
 
-export function errorResponse(message: string, status = 400): Response {
-  return jsonResponse({ error: message }, status);
+export function errorResponse(message: string, status = 400, origin?: string | null): Response {
+  return jsonResponse({ error: message }, status, origin);
 }

--- a/netlify/functions/audit.ts
+++ b/netlify/functions/audit.ts
@@ -5,11 +5,14 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
-  if (request.method !== 'GET') return errorResponse('Method not allowed', 405);
+  if (request.method === 'OPTIONS') return handleOptions(request);
+
+  const origin = request.headers.get('Origin');
+
+  if (request.method !== 'GET') return errorResponse('Method not allowed', 405, origin);
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   const url = new URL(request.url);
   const page = parseInt(url.searchParams.get('page') || '1');
@@ -32,7 +35,7 @@ export default async function handler(request: Request, _context: Context) {
     .range((page - 1) * perPage, page * perPage - 1);
 
   const { data, error, count } = await query;
-  if (error) return errorResponse(error.message, 500);
+  if (error) return errorResponse(error.message, 500, origin);
 
-  return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage });
+  return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage }, 200, origin);
 }

--- a/netlify/functions/blog-posts.ts
+++ b/netlify/functions/blog-posts.ts
@@ -4,9 +4,14 @@ import { jsonResponse, errorResponse } from './_shared/response';
 import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
-export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+function sanitizeSearch(input: string): string {
+  return input.replace(/[,.()"\\]/g, '').trim();
+}
 
+export default async function handler(request: Request, _context: Context) {
+  if (request.method === 'OPTIONS') return handleOptions(request);
+
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/blog-posts\/?/, '').split('/').filter(Boolean);
   const slugOrId = pathParts[0];
@@ -22,15 +27,15 @@ export default async function handler(request: Request, _context: Context) {
         .eq('slug', slugOrId)
         .single();
 
-      if (error || !data) return errorResponse('Post not found', 404);
+      if (error || !data) return errorResponse('Post not found', 404, origin);
 
       // If not published, require admin
       if (data.status !== 'published') {
         const auth = await verifyAuth(request);
-        if (!requireAdmin(auth)) return errorResponse('Not found', 404);
+        if (!requireAdmin(auth)) return errorResponse('Not found', 404, origin);
       }
 
-      return jsonResponse(data);
+      return jsonResponse(data, 200, origin);
     }
 
     // List posts
@@ -66,14 +71,17 @@ export default async function handler(request: Request, _context: Context) {
 
     if (category) query = query.eq('category', category);
     if (tag) query = query.contains('tags', [tag]);
-    if (search) query = query.or(`title.ilike.%${search}%,content.ilike.%${search}%`);
+    if (search) {
+      const safe = sanitizeSearch(search);
+      if (safe) query = query.or(`title.ilike.%${safe}%,content.ilike.%${safe}%`);
+    }
 
     query = query
       .order('published_at', { ascending: false, nullsFirst: false })
       .range((page - 1) * perPage, page * perPage - 1);
 
     const { data, error, count } = await query;
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
 
     return jsonResponse({
       data: data ?? [],
@@ -81,19 +89,19 @@ export default async function handler(request: Request, _context: Context) {
       page,
       per_page: perPage,
       has_more: (count ?? 0) > page * perPage,
-    });
+    }, 200, origin);
   }
 
   // POST/PUT/DELETE - admin only
   const auth = await verifyAuth(request);
   if (!requireAdmin(auth)) {
-    return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+    return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
   }
 
   if (request.method === 'POST') {
     const body = await request.json();
     const { data, error } = await supabase.from('blog_posts').insert(body).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
 
     await supabase.rpc('log_audit_event', {
       p_action: 'create',
@@ -103,16 +111,16 @@ export default async function handler(request: Request, _context: Context) {
       p_new_values: body,
     });
 
-    return jsonResponse(data, 201);
+    return jsonResponse(data, 201, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!slugOrId) return errorResponse('ID required', 400);
+    if (!slugOrId) return errorResponse('ID required', 400, origin);
     const body = await request.json();
 
     const { data: old } = await supabase.from('blog_posts').select('*').eq('id', slugOrId).single();
     const { data, error } = await supabase.from('blog_posts').update(body).eq('id', slugOrId).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
 
     await supabase.rpc('log_audit_event', {
       p_action: 'update',
@@ -122,15 +130,15 @@ export default async function handler(request: Request, _context: Context) {
       p_new_values: body,
     });
 
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!slugOrId) return errorResponse('ID required', 400);
+    if (!slugOrId) return errorResponse('ID required', 400, origin);
 
     const { data: old } = await supabase.from('blog_posts').select('*').eq('id', slugOrId).single();
     const { error } = await supabase.from('blog_posts').delete().eq('id', slugOrId);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
 
     await supabase.rpc('log_audit_event', {
       p_action: 'delete',
@@ -140,8 +148,8 @@ export default async function handler(request: Request, _context: Context) {
       p_new_values: null,
     });
 
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/faqs.ts
+++ b/netlify/functions/faqs.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/faqs\/?/, '').split('/').filter(Boolean);
   const id = pathParts[0];
@@ -25,39 +26,39 @@ export default async function handler(request: Request, _context: Context) {
 
     query = query.order('display_order', { ascending: true });
     const { data, error } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse(data ?? []);
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse(data ?? [], 200, origin);
   }
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'POST') {
     const body = await request.json();
     const { data, error } = await supabase.from('faqs').insert(body).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'create', p_table_name: 'faqs', p_record_id: data.id, p_old_values: null, p_new_values: body });
-    return jsonResponse(data, 201);
+    return jsonResponse(data, 201, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const body = await request.json();
     const { data: old } = await supabase.from('faqs').select('*').eq('id', id).single();
     const { data, error } = await supabase.from('faqs').update(body).eq('id', id).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'faqs', p_record_id: id, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const { data: old } = await supabase.from('faqs').select('*').eq('id', id).single();
     const { error } = await supabase.from('faqs').delete().eq('id', id);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'delete', p_table_name: 'faqs', p_record_id: id, p_old_values: old, p_new_values: null });
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/leads.ts
+++ b/netlify/functions/leads.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/leads\/?/, '').split('/').filter(Boolean);
   const id = pathParts[0];
@@ -14,7 +15,7 @@ export default async function handler(request: Request, _context: Context) {
 
   // All lead endpoints are admin-only
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'GET') {
     const page = parseInt(url.searchParams.get('page') || '1');
@@ -29,28 +30,28 @@ export default async function handler(request: Request, _context: Context) {
       .range((page - 1) * perPage, page * perPage - 1);
 
     const { data, error, count } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage });
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage }, 200, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const body = await request.json();
     const { data: old } = await supabase.from('leads').select('*').eq('id', id).single();
     const { data, error } = await supabase.from('leads').update(body).eq('id', id).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'leads', p_record_id: id, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const { data: old } = await supabase.from('leads').select('*').eq('id', id).single();
     const { error } = await supabase.from('leads').delete().eq('id', id);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'delete', p_table_name: 'leads', p_record_id: id, p_old_values: old, p_new_values: null });
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/pages.ts
+++ b/netlify/functions/pages.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/pages\/?/, '').split('/').filter(Boolean);
   const slugOrId = pathParts[0];
@@ -14,18 +15,27 @@ export default async function handler(request: Request, _context: Context) {
 
   if (request.method === 'GET') {
     if (slugOrId) {
-      const { data, error } = await supabase
+      // Try by slug first, then fall back to ID lookup
+      let { data, error } = await supabase
         .from('pages')
         .select('*, sections:page_sections(*)')
-        .or(`slug.eq.${slugOrId},id.eq.${slugOrId}`)
-        .single();
+        .eq('slug', slugOrId)
+        .maybeSingle();
 
-      if (error || !data) return errorResponse('Page not found', 404);
+      if (!data && !error) {
+        ({ data, error } = await supabase
+          .from('pages')
+          .select('*, sections:page_sections(*)')
+          .eq('id', slugOrId)
+          .maybeSingle());
+      }
+
+      if (error || !data) return errorResponse('Page not found', 404, origin);
       if (!data.is_published) {
         const auth = await verifyAuth(request);
-        if (!requireAdmin(auth)) return errorResponse('Not found', 404);
+        if (!requireAdmin(auth)) return errorResponse('Not found', 404, origin);
       }
-      return jsonResponse(data);
+      return jsonResponse(data, 200, origin);
     }
 
     let query = supabase.from('pages').select('*, sections:page_sections(*)');
@@ -39,18 +49,18 @@ export default async function handler(request: Request, _context: Context) {
     }
 
     const { data, error } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse(data ?? []);
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse(data ?? [], 200, origin);
   }
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'POST') {
     const body = await request.json();
     const { sections, ...pageData } = body;
     const { data, error } = await supabase.from('pages').insert(pageData).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
 
     if (sections?.length) {
       const sectionsWithPageId = sections.map((s: Record<string, unknown>, i: number) => ({ ...s, page_id: data.id, position: s.position ?? i }));
@@ -58,16 +68,16 @@ export default async function handler(request: Request, _context: Context) {
     }
 
     await supabase.rpc('log_audit_event', { p_action: 'create', p_table_name: 'pages', p_record_id: data.id, p_old_values: null, p_new_values: body });
-    return jsonResponse(data, 201);
+    return jsonResponse(data, 201, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!slugOrId) return errorResponse('ID required', 400);
+    if (!slugOrId) return errorResponse('ID required', 400, origin);
     const body = await request.json();
     const { sections, ...pageData } = body;
     const { data: old } = await supabase.from('pages').select('*').eq('id', slugOrId).single();
     const { data, error } = await supabase.from('pages').update(pageData).eq('id', slugOrId).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
 
     if (sections) {
       await supabase.from('page_sections').delete().eq('page_id', slugOrId);
@@ -78,18 +88,18 @@ export default async function handler(request: Request, _context: Context) {
     }
 
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'pages', p_record_id: slugOrId, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!slugOrId) return errorResponse('ID required', 400);
+    if (!slugOrId) return errorResponse('ID required', 400, origin);
     const { data: old } = await supabase.from('pages').select('*').eq('id', slugOrId).single();
     await supabase.from('page_sections').delete().eq('page_id', slugOrId);
     const { error } = await supabase.from('pages').delete().eq('id', slugOrId);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'delete', p_table_name: 'pages', p_record_id: slugOrId, p_old_values: old, p_new_values: null });
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/photos.ts
+++ b/netlify/functions/photos.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/photos\/?/, '').split('/').filter(Boolean);
   const id = pathParts[0];
@@ -19,39 +20,39 @@ export default async function handler(request: Request, _context: Context) {
     query = query.order('display_order', { ascending: true }).order('created_at', { ascending: false });
 
     const { data, error, count } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse({ data: data ?? [], total: count ?? 0 });
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse({ data: data ?? [], total: count ?? 0 }, 200, origin);
   }
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'POST') {
     const body = await request.json();
     const { data, error } = await supabase.from('portfolio_photos').insert(body).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'create', p_table_name: 'portfolio_photos', p_record_id: data.id, p_old_values: null, p_new_values: body });
-    return jsonResponse(data, 201);
+    return jsonResponse(data, 201, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const body = await request.json();
     const { data: old } = await supabase.from('portfolio_photos').select('*').eq('id', id).single();
     const { data, error } = await supabase.from('portfolio_photos').update(body).eq('id', id).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'portfolio_photos', p_record_id: id, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const { data: old } = await supabase.from('portfolio_photos').select('*').eq('id', id).single();
     const { error } = await supabase.from('portfolio_photos').delete().eq('id', id);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'delete', p_table_name: 'portfolio_photos', p_record_id: id, p_old_values: old, p_new_values: null });
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/projects.ts
+++ b/netlify/functions/projects.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/projects\/?/, '').split('/').filter(Boolean);
   const slugOrId = pathParts[0];
@@ -14,18 +15,27 @@ export default async function handler(request: Request, _context: Context) {
 
   if (request.method === 'GET') {
     if (slugOrId) {
-      const { data, error } = await supabase
+      // Try by slug first, then fall back to ID lookup
+      let { data, error } = await supabase
         .from('projects')
         .select('*, photos:portfolio_photos(*)')
-        .or(`slug.eq.${slugOrId},id.eq.${slugOrId}`)
-        .single();
+        .eq('slug', slugOrId)
+        .maybeSingle();
 
-      if (error || !data) return errorResponse('Project not found', 404);
+      if (!data && !error) {
+        ({ data, error } = await supabase
+          .from('projects')
+          .select('*, photos:portfolio_photos(*)')
+          .eq('id', slugOrId)
+          .maybeSingle());
+      }
+
+      if (error || !data) return errorResponse('Project not found', 404, origin);
       if (!data.is_published) {
         const auth = await verifyAuth(request);
-        if (!requireAdmin(auth)) return errorResponse('Not found', 404);
+        if (!requireAdmin(auth)) return errorResponse('Not found', 404, origin);
       }
-      return jsonResponse(data);
+      return jsonResponse(data, 200, origin);
     }
 
     const page = parseInt(url.searchParams.get('page') || '1');
@@ -52,39 +62,39 @@ export default async function handler(request: Request, _context: Context) {
       .range((page - 1) * perPage, page * perPage - 1);
 
     const { data, error, count } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage });
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage }, 200, origin);
   }
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'POST') {
     const body = await request.json();
     const { data, error } = await supabase.from('projects').insert(body).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'create', p_table_name: 'projects', p_record_id: data.id, p_old_values: null, p_new_values: body });
-    return jsonResponse(data, 201);
+    return jsonResponse(data, 201, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!slugOrId) return errorResponse('ID required', 400);
+    if (!slugOrId) return errorResponse('ID required', 400, origin);
     const body = await request.json();
     const { data: old } = await supabase.from('projects').select('*').eq('id', slugOrId).single();
     const { data, error } = await supabase.from('projects').update(body).eq('id', slugOrId).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'projects', p_record_id: slugOrId, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!slugOrId) return errorResponse('ID required', 400);
+    if (!slugOrId) return errorResponse('ID required', 400, origin);
     const { data: old } = await supabase.from('projects').select('*').eq('id', slugOrId).single();
     const { error } = await supabase.from('projects').delete().eq('id', slugOrId);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'delete', p_table_name: 'projects', p_record_id: slugOrId, p_old_values: old, p_new_values: null });
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/reviews.ts
+++ b/netlify/functions/reviews.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/reviews\/?/, '').split('/').filter(Boolean);
   const id = pathParts[0];
@@ -16,8 +17,8 @@ export default async function handler(request: Request, _context: Context) {
     // Return aggregates if requested
     if (url.searchParams.get('aggregates') === 'true') {
       const { data, error } = await supabase.from('review_aggregates').select('*');
-      if (error) return errorResponse(error.message, 500);
-      return jsonResponse(data ?? []);
+      if (error) return errorResponse(error.message, 500, origin);
+      return jsonResponse(data ?? [], 200, origin);
     }
 
     const page = parseInt(url.searchParams.get('page') || '1');
@@ -43,42 +44,42 @@ export default async function handler(request: Request, _context: Context) {
       .range((page - 1) * perPage, page * perPage - 1);
 
     const { data, error, count } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage });
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse({ data: data ?? [], total: count ?? 0, page, per_page: perPage, has_more: (count ?? 0) > page * perPage }, 200, origin);
   }
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'POST') {
     const body = await request.json();
     const { data, error } = await supabase.from('reviews').insert(body).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('refresh_review_aggregates', { p_source: body.source || null });
     await supabase.rpc('log_audit_event', { p_action: 'create', p_table_name: 'reviews', p_record_id: data.id, p_old_values: null, p_new_values: body });
-    return jsonResponse(data, 201);
+    return jsonResponse(data, 201, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const body = await request.json();
     const { data: old } = await supabase.from('reviews').select('*').eq('id', id).single();
     const { data, error } = await supabase.from('reviews').update(body).eq('id', id).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('refresh_review_aggregates');
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'reviews', p_record_id: id, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const { data: old } = await supabase.from('reviews').select('*').eq('id', id).single();
     const { error } = await supabase.from('reviews').delete().eq('id', id);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('refresh_review_aggregates');
     await supabase.rpc('log_audit_event', { p_action: 'delete', p_table_name: 'reviews', p_record_id: id, p_old_values: old, p_new_values: null });
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/settings.ts
+++ b/netlify/functions/settings.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/settings\/?/, '').split('/').filter(Boolean);
   const key = pathParts[0];
@@ -15,20 +16,20 @@ export default async function handler(request: Request, _context: Context) {
   if (request.method === 'GET') {
     if (key) {
       const { data, error } = await supabase.from('site_settings').select('*').eq('key', key).single();
-      if (error) return errorResponse('Setting not found', 404);
-      return jsonResponse(data);
+      if (error) return errorResponse('Setting not found', 404, origin);
+      return jsonResponse(data, 200, origin);
     }
 
     const category = url.searchParams.get('category');
     let query = supabase.from('site_settings').select('*');
     if (category) query = query.eq('category', category);
     const { data, error } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse(data ?? []);
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse(data ?? [], 200, origin);
   }
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'PUT') {
     const body = await request.json();
@@ -43,25 +44,25 @@ export default async function handler(request: Request, _context: Context) {
           .upsert({ key: setting.key, value: setting.value, category: setting.category || 'general' }, { onConflict: 'key' })
           .select()
           .single();
-        if (error) return errorResponse(error.message, 500);
+        if (error) return errorResponse(error.message, 500, origin);
         await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'site_settings', p_record_id: data.id, p_old_values: old, p_new_values: setting });
         results.push(data);
       }
-      return jsonResponse(results);
+      return jsonResponse(results, 200, origin);
     }
 
     // Single update
-    if (!key) return errorResponse('Key required', 400);
+    if (!key) return errorResponse('Key required', 400, origin);
     const { data: old } = await supabase.from('site_settings').select('*').eq('key', key).single();
     const { data, error } = await supabase
       .from('site_settings')
       .upsert({ key, value: body.value, category: body.category || 'general' }, { onConflict: 'key' })
       .select()
       .single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'site_settings', p_record_id: data.id, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/team.ts
+++ b/netlify/functions/team.ts
@@ -5,8 +5,9 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
+  if (request.method === 'OPTIONS') return handleOptions(request);
 
+  const origin = request.headers.get('Origin');
   const url = new URL(request.url);
   const pathParts = url.pathname.replace(/^\/api\/team\/?/, '').split('/').filter(Boolean);
   const id = pathParts[0];
@@ -25,39 +26,39 @@ export default async function handler(request: Request, _context: Context) {
 
     query = query.order('display_order', { ascending: true });
     const { data, error } = await query;
-    if (error) return errorResponse(error.message, 500);
-    return jsonResponse(data ?? []);
+    if (error) return errorResponse(error.message, 500, origin);
+    return jsonResponse(data ?? [], 200, origin);
   }
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   if (request.method === 'POST') {
     const body = await request.json();
     const { data, error } = await supabase.from('team_members').insert(body).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'create', p_table_name: 'team_members', p_record_id: data.id, p_old_values: null, p_new_values: body });
-    return jsonResponse(data, 201);
+    return jsonResponse(data, 201, origin);
   }
 
   if (request.method === 'PUT') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const body = await request.json();
     const { data: old } = await supabase.from('team_members').select('*').eq('id', id).single();
     const { data, error } = await supabase.from('team_members').update(body).eq('id', id).select().single();
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'update', p_table_name: 'team_members', p_record_id: id, p_old_values: old, p_new_values: body });
-    return jsonResponse(data);
+    return jsonResponse(data, 200, origin);
   }
 
   if (request.method === 'DELETE') {
-    if (!id) return errorResponse('ID required', 400);
+    if (!id) return errorResponse('ID required', 400, origin);
     const { data: old } = await supabase.from('team_members').select('*').eq('id', id).single();
     const { error } = await supabase.from('team_members').delete().eq('id', id);
-    if (error) return errorResponse(error.message, 500);
+    if (error) return errorResponse(error.message, 500, origin);
     await supabase.rpc('log_audit_event', { p_action: 'delete', p_table_name: 'team_members', p_record_id: id, p_old_values: old, p_new_values: null });
-    return jsonResponse({ success: true });
+    return jsonResponse({ success: true }, 200, origin);
   }
 
-  return errorResponse('Method not allowed', 405);
+  return errorResponse('Method not allowed', 405, origin);
 }

--- a/netlify/functions/upload.ts
+++ b/netlify/functions/upload.ts
@@ -5,22 +5,25 @@ import { getSupabaseAdmin } from './_shared/supabase';
 import { verifyAuth, requireAdmin } from './_shared/auth';
 
 export default async function handler(request: Request, _context: Context) {
-  if (request.method === 'OPTIONS') return handleOptions();
-  if (request.method !== 'POST') return errorResponse('Method not allowed', 405);
+  if (request.method === 'OPTIONS') return handleOptions(request);
+
+  const origin = request.headers.get('Origin');
+
+  if (request.method !== 'POST') return errorResponse('Method not allowed', 405, origin);
 
   const auth = await verifyAuth(request);
-  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403);
+  if (!requireAdmin(auth)) return auth instanceof Response ? auth : errorResponse('Forbidden', 403, origin);
 
   const contentType = request.headers.get('Content-Type') || '';
   if (!contentType.includes('multipart/form-data')) {
-    return errorResponse('Content-Type must be multipart/form-data', 400);
+    return errorResponse('Content-Type must be multipart/form-data', 400, origin);
   }
 
   const formData = await request.formData();
   const file = formData.get('file') as File | null;
   const bucket = (formData.get('bucket') as string) || 'photos';
 
-  if (!file) return errorResponse('No file provided', 400);
+  if (!file) return errorResponse('No file provided', 400, origin);
 
   const supabase = getSupabaseAdmin();
   const ext = file.name.split('.').pop();
@@ -33,9 +36,9 @@ export default async function handler(request: Request, _context: Context) {
     upsert: false,
   });
 
-  if (error) return errorResponse(error.message, 500);
+  if (error) return errorResponse(error.message, 500, origin);
 
   const { data: urlData } = supabase.storage.from(bucket).getPublicUrl(filePath);
 
-  return jsonResponse({ url: urlData.publicUrl, path: filePath, bucket });
+  return jsonResponse({ url: urlData.publicUrl, path: filePath, bucket }, 200, origin);
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,22 @@
+import { Component, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -21,6 +21,7 @@ import {
   BookOpen,
 } from 'lucide-react';
 import { useClerk, UserButton } from '@clerk/clerk-react';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 interface NavItem {
   to: string;
@@ -275,7 +276,19 @@ export default function AdminLayout() {
 
         {/* Page Content */}
         <main className="flex-1 p-4 sm:p-6 lg:p-8 overflow-auto">
-          <Outlet />
+          <ErrorBoundary fallback={
+            <div className="flex items-center justify-center py-20">
+              <div className="text-center max-w-md">
+                <h2 className="text-2xl font-bold text-gray-900 mb-4">Something went wrong</h2>
+                <p className="text-gray-600 mb-6">An error occurred while loading this page.</p>
+                <a href="/admin" className="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors">
+                  Back to Dashboard
+                </a>
+              </div>
+            </div>
+          }>
+            <Outlet />
+          </ErrorBoundary>
         </main>
       </div>
     </div>

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -15,6 +15,7 @@ import {
   ArrowRight,
 } from 'lucide-react';
 import ThemeToggle from '../components/navigation/ThemeToggle';
+import ErrorBoundary from '../components/ErrorBoundary';
 import { MainSchemas } from '@/lib/seo';
 import { trackPageView, trackPhoneClick, trackEmailClick } from '@/lib/analytics';
 
@@ -325,7 +326,17 @@ export default function PublicLayout() {
 
       {/* Main Content */}
       <main className="flex-1">
-        <Outlet />
+        <ErrorBoundary fallback={
+          <div className="flex-1 flex items-center justify-center py-20">
+            <div className="text-center max-w-md px-4">
+              <h2 className="font-display text-2xl font-semibold text-t-text mb-4">Something went wrong</h2>
+              <p className="text-t-text-secondary mb-6">We encountered an unexpected error loading this page.</p>
+              <a href="/" className="btn-gold px-6 py-3">Return Home</a>
+            </div>
+          </div>
+        }>
+          <Outlet />
+        </ErrorBoundary>
       </main>
 
       {/* Footer - Editorial Style */}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom';
 import { ClerkProvider } from '@clerk/clerk-react';
 import { router } from './routes/router';
 import { ThemeProvider } from './contexts/ThemeContext';
+import ErrorBoundary from './components/ErrorBoundary';
 import { initializeBaseMeta } from './lib/seo';
 import './index.css';
 
@@ -12,11 +13,20 @@ initializeBaseMeta();
 
 const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 
+const globalFallback = (
+  <div style={{ padding: '2rem', textAlign: 'center' }}>
+    <h1>Something went wrong</h1>
+    <p>Please refresh the page.</p>
+  </div>
+);
+
 const app = (
   <StrictMode>
-    <ThemeProvider>
-      <RouterProvider router={router} />
-    </ThemeProvider>
+    <ErrorBoundary fallback={globalFallback}>
+      <ThemeProvider>
+        <RouterProvider router={router} />
+      </ThemeProvider>
+    </ErrorBoundary>
   </StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- **PostgREST injection**: Replace unsafe `.or()` interpolation in `projects.ts` and `pages.ts` with two sequential `.eq()` queries; add `sanitizeSearch()` in `blog-posts.ts` to strip operator characters from search input
- **CORS restriction**: Replace `Access-Control-Allow-Origin: *` with origin-aware allowlist via `ALLOWED_ORIGINS` env var (all 11 Netlify Functions updated)
- **React ErrorBoundary**: New class component wrapping the app at 3 levels (global in `main.tsx`, public layout `<Outlet />`, admin layout `<Outlet />`) to prevent white-screen crashes

## Test plan
- [ ] `npm run build` passes with no errors
- [ ] Verify `/api/projects/foo,is_published.eq.false` returns 404 (injection blocked)
- [ ] Verify CORS: requests from allowed origins succeed; others get production domain in header
- [ ] Set `ALLOWED_ORIGINS` env var in Netlify dashboard: `https://christensenplumbing.com,http://localhost:8888`
- [ ] Temporarily throw in a component render to confirm ErrorBoundary fallback UI appears instead of white screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)